### PR TITLE
Add multi-architecture support to Docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,6 +28,10 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # Set up QEMU for multi-architecture builds
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       # Build and push
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -35,6 +39,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             oborchers/mcp-server-docy:latest
             oborchers/mcp-server-docy:${{ env.TAG_VERSION }}


### PR DESCRIPTION
This change enables building and publishing Docker images for both amd64 and arm64 architectures. It adds the docker/setup-qemu-action which is required for multi-architecture builds, and specifies the platforms parameter in the build-push-action configuration.

This resolves the issue where ARM64 users (like Apple Silicon Macs) were unable to run the Docker image due to missing arm64 support.

🤖 Generated with [Claude Code](https://claude.ai/code)